### PR TITLE
HIVE-14784: Operation logs are disabled automatically if the parent d…

### DIFF
--- a/service/src/java/org/apache/hive/service/cli/operation/Operation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/Operation.java
@@ -234,6 +234,17 @@ public abstract class Operation {
               operationLogFile.getAbsolutePath());
           operationLogFile.delete();
         }
+        if (!operationLogFile.getParentFile().exists()) {
+          LOG.warn("Operations log directory for this session does not exist, it could have been deleted " +
+              "externally. Recreating the directory for future queries in this session but the older operation " +
+              "logs for this session are no longer available");
+          if (!operationLogFile.getParentFile().mkdir()) {
+            LOG.warn("Log directory for this session could not be created, disabling " +
+                "operation logs: " + operationLogFile.getParentFile().getAbsolutePath());
+            isOperationLogEnabled = false;
+            return;
+          }
+        }
         if (!operationLogFile.createNewFile()) {
           // the log file already exists and cannot be deleted.
           // If it can be read/written, keep its contents and use it.


### PR DESCRIPTION
…irectory does not exist. (Naveen Gangam via Yongzhi Chen)
